### PR TITLE
Auto-open mac screen recording settings

### DIFF
--- a/main.js
+++ b/main.js
@@ -226,6 +226,7 @@ ipcMain.on('request-permission-dialog', () => {
   }
   permissionWindow.show();
   permissionWindow.focus();
+  openMacScreenRecordingSettings();
 });
 
 ipcMain.on('close-permission-dialog', () => {
@@ -235,7 +236,14 @@ ipcMain.on('close-permission-dialog', () => {
 });
 
 ipcMain.on('open-permission-settings', () => {
+  openMacScreenRecordingSettings();
+});
+
+function openMacScreenRecordingSettings() {
+  if (process.platform !== 'darwin') {
+    return;
+  }
   const macSettingsUrl = 'x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture';
   shell.openExternal(macSettingsUrl);
-});
+}
 

--- a/renderer/permission/index.html
+++ b/renderer/permission/index.html
@@ -10,8 +10,9 @@
     <main>
       <h1>Enable Screen Recording</h1>
       <p>
-        Neptune needs screen recording permission to capture your desktop. Enable it in
-        System Settings → Privacy &amp; Security → Screen Recording.
+        Neptune needs screen recording permission to capture your desktop. System Settings should
+        open automatically to Privacy &amp; Security → Screen Recording so you can enable access. If it
+        doesn't, use the button below to open it manually.
       </p>
       <div class="actions">
         <button id="settings">Open System Settings</button>


### PR DESCRIPTION
## Summary
- automatically launch macOS Screen Recording privacy pane whenever the permission dialog appears
- centralize screen recording settings opening logic and reuse it for the manual "Open System Settings" action
- update permission dialog copy to explain that System Settings opens automatically and the button is only a fallback

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d38696e418832cb2aea9847d517dc7