### PR TITLE
Refine Neptune chat overlay with glassmorphic UI

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -4,15 +4,22 @@ contextBridge.exposeInMainWorld('electronAPI', {
   openChat: () => ipcRenderer.send('open-chat'),
   hideChat: () => ipcRenderer.send('hide-chat'),
   onChatOpened: (callback) => {
-    ipcRenderer.removeAllListeners('chat-opened');
-    ipcRenderer.on('chat-opened', (_event) => callback());
+    const listener = () => callback();
+    ipcRenderer.on('chat-opened', listener);
+    return () => ipcRenderer.removeListener('chat-opened', listener);
+  },
+  onChatClosed: (callback) => {
+    const listener = () => callback();
+    ipcRenderer.on('chat-closed', listener);
+    return () => ipcRenderer.removeListener('chat-closed', listener);
   },
   getPrimaryDisplay: () => ipcRenderer.invoke('get-primary-display'),
   saveCapture: (payload) => ipcRenderer.invoke('save-capture', payload),
   startCursorAnimation: () => ipcRenderer.send('start-animation'),
   onStartAnimation: (callback) => {
-    ipcRenderer.removeAllListeners('start-animation');
-    ipcRenderer.on('start-animation', (_event, points) => callback(points));
+    const listener = (_event, payload) => callback(payload);
+    ipcRenderer.on('start-animation', listener);
+    return () => ipcRenderer.removeListener('start-animation', listener);
   },
   animationComplete: () => ipcRenderer.send('animation-complete'),
   showPermissionDialog: () => ipcRenderer.send('request-permission-dialog'),

--- a/renderer/animation/script.js
+++ b/renderer/animation/script.js
@@ -3,6 +3,7 @@ const tooltip = document.getElementById('tooltip');
 const tooltipText = document.getElementById('tooltip-text');
 
 let animationFrame;
+let dwellTimeout;
 
 function setCursorPosition(x, y) {
   cursor.style.left = `${x}px`;
@@ -15,32 +16,53 @@ function setTooltipPosition(x, y, message) {
   tooltipText.textContent = message;
 }
 
-function animatePoints(points) {
-  if (!points || points.length === 0) {
+function animatePoints(payload) {
+  const { points = [], origin = null } = Array.isArray(payload)
+    ? { points: payload, origin: null }
+    : payload || {};
+
+  if (!Array.isArray(points) || points.length === 0) {
     window.electronAPI.animationComplete();
     return;
   }
 
-  cursor.style.opacity = '1';
-  tooltip.classList.remove('hidden');
-  tooltip.classList.add('visible');
+  cancelAnimationFrame(animationFrame);
+  clearTimeout(dwellTimeout);
 
-  let currentIndex = 0;
-  let currentPosition = { x: points[0].x, y: points[0].y };
-  setCursorPosition(currentPosition.x, currentPosition.y);
-  setTooltipPosition(currentPosition.x, currentPosition.y, points[0].message);
-
+  const sequence = points.map((point) => ({ ...point }));
   const travelDuration = 750;
   const dwellDuration = 700;
+  const entryDuration = 520;
+
+  let currentIndex = 0;
+
+  const queueNext = () => {
+    clearTimeout(dwellTimeout);
+    if (currentIndex >= sequence.length - 1) {
+      dwellTimeout = setTimeout(finishAnimation, dwellDuration);
+    } else {
+      dwellTimeout = setTimeout(moveToNext, dwellDuration);
+    }
+  };
+
+  const startAtFirstPoint = () => {
+    const first = sequence[0];
+    currentIndex = 0;
+    setCursorPosition(first.x, first.y);
+    setTooltipPosition(first.x, first.y, first.message);
+    tooltip.classList.remove('hidden');
+    tooltip.classList.add('visible');
+    queueNext();
+  };
 
   const moveToNext = () => {
-    if (currentIndex >= points.length - 1) {
+    if (currentIndex >= sequence.length - 1) {
       finishAnimation();
       return;
     }
 
-    const start = { ...currentPosition };
-    const target = points[currentIndex + 1];
+    const start = sequence[currentIndex];
+    const target = sequence[currentIndex + 1];
     const startTime = performance.now();
 
     const step = (now) => {
@@ -48,7 +70,6 @@ function animatePoints(points) {
       const eased = easeOutCubic(progress);
       const x = start.x + (target.x - start.x) * eased;
       const y = start.y + (target.y - start.y) * eased;
-      currentPosition = { x, y };
       setCursorPosition(x, y);
       setTooltipPosition(x, y, target.message);
 
@@ -56,20 +77,40 @@ function animatePoints(points) {
         animationFrame = requestAnimationFrame(step);
       } else {
         currentIndex += 1;
-        setTimeout(moveToNext, dwellDuration);
+        queueNext();
       }
     };
 
     animationFrame = requestAnimationFrame(step);
   };
 
-  setTimeout(() => {
-    if (points.length === 1) {
-      finishAnimation();
-    } else {
-      moveToNext();
-    }
-  }, dwellDuration);
+  cursor.style.opacity = '1';
+
+  if (origin) {
+    tooltip.classList.add('hidden');
+    tooltip.classList.remove('visible');
+    const entryStart = performance.now();
+    const entryOrigin = { x: origin.x, y: origin.y };
+    const first = sequence[0];
+
+    const entryStep = (now) => {
+      const progress = Math.min((now - entryStart) / entryDuration, 1);
+      const eased = easeOutCubic(progress);
+      const x = entryOrigin.x + (first.x - entryOrigin.x) * eased;
+      const y = entryOrigin.y + (first.y - entryOrigin.y) * eased;
+      setCursorPosition(x, y);
+
+      if (progress < 1) {
+        animationFrame = requestAnimationFrame(entryStep);
+      } else {
+        startAtFirstPoint();
+      }
+    };
+
+    animationFrame = requestAnimationFrame(entryStep);
+  } else {
+    startAtFirstPoint();
+  }
 }
 
 function easeOutCubic(t) {
@@ -78,15 +119,16 @@ function easeOutCubic(t) {
 
 function finishAnimation() {
   cancelAnimationFrame(animationFrame);
+  clearTimeout(dwellTimeout);
   cursor.style.opacity = '0';
   tooltip.classList.remove('visible');
   tooltip.classList.add('hidden');
   window.electronAPI.animationComplete();
 }
 
-window.electronAPI.onStartAnimation((points) => {
+window.electronAPI.onStartAnimation((payload) => {
   cursor.style.opacity = '0';
   tooltip.classList.add('hidden');
   tooltip.classList.remove('visible');
-  animatePoints(points);
+  animatePoints(payload);
 });

--- a/renderer/animation/styles.css
+++ b/renderer/animation/styles.css
@@ -23,8 +23,8 @@ body {
   height: 24px;
   border-radius: 50% 50% 50% 10%;
   transform: translate(-50%, -50%) rotate(45deg);
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(180, 210, 255, 0.9));
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(164, 206, 255, 0.9));
+  box-shadow: 0 12px 28px rgba(40, 82, 160, 0.35), 0 0 18px rgba(140, 196, 255, 0.65);
   pointer-events: none;
   opacity: 0;
   transition: opacity 0.2s ease;
@@ -34,11 +34,13 @@ body {
   position: absolute;
   padding: 12px 16px;
   border-radius: 14px;
-  background: rgba(20, 24, 30, 0.78);
-  backdrop-filter: blur(16px);
-  color: #f8fbff;
+  background: linear-gradient(160deg, rgba(24, 34, 58, 0.82), rgba(28, 40, 72, 0.55));
+  border: 1px solid rgba(184, 214, 255, 0.4);
+  backdrop-filter: blur(18px) saturate(160%);
+  color: #f4f8ff;
   font-size: 16px;
-  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.45);
+  box-shadow: 0 28px 48px rgba(14, 22, 48, 0.55), inset 0 0 24px rgba(120, 184, 255, 0.18);
+  text-shadow: 0 0 18px rgba(150, 210, 255, 0.7);
   max-width: 320px;
   transform: translate(-50%, -100%);
   transition: opacity 0.2s ease;
@@ -54,7 +56,7 @@ body {
   transform: translateX(-50%);
   border-width: 8px 8px 0 8px;
   border-style: solid;
-  border-color: rgba(20, 24, 30, 0.78) transparent transparent transparent;
+  border-color: rgba(24, 34, 58, 0.82) transparent transparent transparent;
 }
 
 #tooltip.hidden {

--- a/renderer/chat/index.html
+++ b/renderer/chat/index.html
@@ -7,15 +7,60 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <div class="overlay">
-      <div class="input-wrapper">
-        <textarea
-          id="chat-input"
-          placeholder="Ask the copilot..."
-          rows="1"
-          spellcheck="false"
-        ></textarea>
-        <div id="status" role="status" aria-live="polite"></div>
+    <div class="chat-shell">
+      <div class="chat-panel" role="dialog" aria-label="Neptune copilot chat">
+        <header class="chat-header">
+          <div class="brand">
+            <span class="brand-orb" aria-hidden="true"></span>
+            <div class="brand-copy">
+              <span class="brand-title">Neptune Copilot</span>
+              <span class="brand-subtitle">Glass-clear guidance on demand</span>
+            </div>
+          </div>
+          <button id="collapse-chat" class="ghost-button" aria-label="Collapse copilot chat">
+            <span aria-hidden="true">–</span>
+          </button>
+        </header>
+
+        <section class="insight-section" aria-live="polite">
+          <div class="insight-toolbar">
+            <span id="insight-label" class="insight-label">Overview</span>
+            <div class="insight-controls">
+              <button id="insight-prev" class="ghost-button" aria-label="Previous insight">
+                ‹
+              </button>
+              <span id="insight-counter" class="insight-counter">01 / 02</span>
+              <button id="insight-next" class="ghost-button" aria-label="Next insight">
+                ›
+              </button>
+            </div>
+          </div>
+          <article class="insight-card" data-state="overview">
+            <h2 id="insight-title">All systems ready</h2>
+            <p id="insight-description">
+              Capture anything on your screen and Neptune will wrap it in context, ready for a
+              shareable walkthrough.
+            </p>
+            <ol id="insight-steps" class="insight-steps" aria-label="Next steps"></ol>
+          </article>
+        </section>
+
+        <footer class="chat-input-area">
+          <div class="input-wrapper">
+            <textarea
+              id="chat-input"
+              placeholder="Ask the copilot or describe what you need..."
+              rows="1"
+              spellcheck="false"
+              aria-label="Type a prompt for the copilot"
+            ></textarea>
+            <button id="send-button" class="send-button" aria-label="Capture and share with Neptune">
+              <span class="send-button-glow" aria-hidden="true"></span>
+              <span class="send-button-label">Send</span>
+            </button>
+          </div>
+          <div id="status" role="status" aria-live="polite"></div>
+        </footer>
       </div>
     </div>
     <script src="script.js"></script>

--- a/renderer/chat/script.js
+++ b/renderer/chat/script.js
@@ -1,12 +1,97 @@
 const textarea = document.getElementById('chat-input');
 const status = document.getElementById('status');
+const sendButton = document.getElementById('send-button');
+const collapseButton = document.getElementById('collapse-chat');
+const insightCard = document.querySelector('.insight-card');
+const insightLabel = document.getElementById('insight-label');
+const insightTitle = document.getElementById('insight-title');
+const insightDescription = document.getElementById('insight-description');
+const insightSteps = document.getElementById('insight-steps');
+const insightCounter = document.getElementById('insight-counter');
+const prevButton = document.getElementById('insight-prev');
+const nextButton = document.getElementById('insight-next');
+
 let displayInfo;
+let currentSlide = 0;
+
+const slides = [
+  {
+    id: 'overview',
+    label: 'Overview',
+    title: 'All systems ready',
+    description:
+      'Neptune keeps a floating eye on your canvas. Capture a moment and the copilot will weave the story, complete with highlights and ready-to-share context.'
+  },
+  {
+    id: 'steps',
+    label: 'Next Steps',
+    title: 'Your next moves',
+    description: 'Follow these luminous steps to get the most out of your next capture.',
+    steps: [
+      {
+        title: 'Mark what matters',
+        detail: 'Point the glowing cursor at the area you need the copilot to analyze first.'
+      },
+      {
+        title: 'Let Neptune annotate',
+        detail: 'We layer in guidance, callouts, and next actions while you stay focused on the task.'
+      },
+      {
+        title: 'Share the walkthrough',
+        detail: 'Send polished highlights to your team or replay them anytime from your capture log.'
+      }
+    ]
+  }
+];
+
+function padIndex(value) {
+  return String(value).padStart(2, '0');
+}
+
+function updateInsight(index) {
+  const slide = slides[index];
+  if (!slide) {
+    return;
+  }
+
+  currentSlide = index;
+  insightLabel.textContent = slide.label;
+  insightTitle.textContent = slide.title;
+  insightDescription.textContent = slide.description;
+  insightCard.dataset.state = slide.steps ? 'steps' : 'overview';
+
+  insightSteps.innerHTML = '';
+  if (slide.steps) {
+    slide.steps.forEach((step) => {
+      const item = document.createElement('li');
+      const heading = document.createElement('strong');
+      heading.textContent = step.title;
+      const detail = document.createElement('span');
+      detail.textContent = step.detail;
+      item.append(heading, detail);
+      insightSteps.appendChild(item);
+    });
+  }
+
+  insightCounter.textContent = `${padIndex(index + 1)} / ${padIndex(slides.length)}`;
+  prevButton.disabled = index === 0;
+  nextButton.disabled = index === slides.length - 1;
+
+  insightCard.classList.remove('enter');
+  void insightCard.offsetWidth;
+  insightCard.classList.add('enter');
+}
 
 function adjustHeight() {
   textarea.style.height = 'auto';
   const maxHeight = parseInt(getComputedStyle(textarea).getPropertyValue('max-height'), 10);
   const newHeight = Math.min(maxHeight, textarea.scrollHeight);
-  textarea.style.height = `${Math.max(newHeight, 40)}px`;
+  textarea.style.height = `${Math.max(newHeight, 56)}px`;
+}
+
+function updateSendButtonState() {
+  const hasText = textarea.value.trim().length > 0;
+  sendButton.classList.toggle('is-ready', hasText);
 }
 
 async function ensureDisplayInfo() {
@@ -20,6 +105,7 @@ async function captureAndSave() {
   const text = textarea.value.trim();
   if (!text) {
     status.textContent = 'Type a message before submitting.';
+    updateSendButtonState();
     return;
   }
 
@@ -43,6 +129,7 @@ async function captureAndSave() {
     await window.electronAPI.saveCapture({ dataURL: downscaled });
     textarea.value = '';
     adjustHeight();
+    updateSendButtonState();
     status.textContent = '';
     window.electronAPI.hideChat();
     window.electronAPI.startCursorAnimation();
@@ -70,6 +157,7 @@ async function downscaleDataUrl(dataUrl, scale) {
 textarea.addEventListener('input', () => {
   adjustHeight();
   status.textContent = '';
+  updateSendButtonState();
 });
 
 textarea.addEventListener('keydown', (event) => {
@@ -79,10 +167,35 @@ textarea.addEventListener('keydown', (event) => {
   }
 });
 
+sendButton.addEventListener('click', (event) => {
+  event.preventDefault();
+  captureAndSave();
+});
+
+collapseButton.addEventListener('click', () => {
+  window.electronAPI.hideChat();
+});
+
+prevButton.addEventListener('click', () => {
+  updateInsight(Math.max(0, currentSlide - 1));
+});
+
+nextButton.addEventListener('click', () => {
+  updateInsight(Math.min(slides.length - 1, currentSlide + 1));
+});
+
 window.electronAPI.onChatOpened(() => {
   status.textContent = '';
   adjustHeight();
   textarea.focus();
+  updateInsight(currentSlide);
+  updateSendButtonState();
 });
 
+window.electronAPI.onChatClosed(() => {
+  textarea.blur();
+});
+
+updateInsight(0);
 adjustHeight();
+updateSendButtonState();

--- a/renderer/chat/styles.css
+++ b/renderer/chat/styles.css
@@ -1,5 +1,7 @@
 :root {
   color-scheme: dark;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
 }
 
 * {
@@ -15,48 +17,389 @@ body {
   background: transparent;
   font-family: 'SF Pro Display', 'SF Pro Text', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   display: flex;
-  align-items: center;
-  justify-content: center;
+  align-items: flex-end;
+  justify-content: flex-end;
+  color: #f0f6ff;
 }
 
-.overlay {
-  min-width: 480px;
-  max-width: 680px;
+.chat-shell {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  padding: 18px;
+}
+
+.chat-panel {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 28px;
+  border-radius: 26px;
+  background: linear-gradient(160deg, rgba(15, 21, 40, 0.88), rgba(15, 21, 40, 0.4));
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 40px 80px rgba(5, 8, 20, 0.55);
+  backdrop-filter: blur(30px) saturate(170%);
+}
+
+.chat-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.brand-orb {
+  width: 46px;
+  height: 46px;
+  border-radius: 16px;
+  background: radial-gradient(circle at 30% 25%, rgba(140, 196, 255, 0.92), rgba(52, 92, 255, 0.35));
+  box-shadow: 0 15px 35px rgba(59, 108, 255, 0.45);
+  position: relative;
+  overflow: hidden;
+}
+
+.brand-orb::after {
+  content: '';
+  position: absolute;
+  inset: 6px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.32);
+  box-shadow: inset 0 0 18px rgba(180, 220, 255, 0.35);
+  opacity: 0.8;
+}
+
+.brand-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.brand-title {
+  font-size: 20px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.95);
+  text-shadow: 0 0 18px rgba(148, 200, 255, 0.75);
+}
+
+.brand-subtitle {
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(218, 233, 255, 0.72);
+}
+
+.ghost-button {
+  appearance: none;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(240, 246, 255, 0.82);
+  font-size: 18px;
+  padding: 8px 12px;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+  backdrop-filter: blur(16px);
+  text-shadow: 0 0 12px rgba(130, 190, 255, 0.65);
+}
+
+.chat-header .ghost-button {
+  width: 44px;
+  height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 22px;
+  font-weight: 600;
+}
+
+.ghost-button:hover {
+  transform: translateY(-1px);
+  background: rgba(130, 190, 255, 0.18);
+  border-color: rgba(160, 210, 255, 0.5);
+  color: rgba(255, 255, 255, 0.94);
+}
+
+.ghost-button:disabled {
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.insight-section {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 18px;
+  border-radius: 22px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: linear-gradient(160deg, rgba(18, 28, 52, 0.75), rgba(18, 28, 52, 0.3));
+  box-shadow: inset 0 0 28px rgba(88, 130, 255, 0.18);
+}
+
+.insight-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.insight-label {
+  font-size: 12px;
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+  color: rgba(188, 214, 255, 0.75);
+}
+
+.insight-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 14px;
+  color: rgba(210, 226, 255, 0.75);
+}
+
+.insight-controls .ghost-button {
+  width: 38px;
+  height: 38px;
+  font-size: 20px;
+  line-height: 1;
+}
+
+.insight-counter {
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.1em;
+}
+
+.insight-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 4px 2px;
+  color: rgba(240, 246, 255, 0.95);
+}
+
+.insight-card::before {
+  content: '';
+  position: absolute;
+  inset: -18px -14px -18px -14px;
   border-radius: 20px;
-  padding: 20px 24px;
-  background: rgba(15, 17, 24, 0.25);
-  backdrop-filter: blur(10px) saturate(160%);
-  box-shadow: 0 32px 60px rgba(0, 0, 0, 0.35);
+  background: radial-gradient(circle at 10% 10%, rgba(120, 180, 255, 0.18), transparent 60%);
+  opacity: 0.9;
+  filter: blur(0.5px);
+  z-index: -1;
+}
+
+.insight-card h2 {
+  margin: 0;
+  font-size: 30px;
+  font-weight: 600;
+  line-height: 1.2;
+  text-shadow: 0 0 24px rgba(152, 206, 255, 0.85);
+}
+
+.insight-card p {
+  margin: 0;
+  font-size: 16px;
+  line-height: 1.6;
+  color: rgba(220, 234, 255, 0.82);
+}
+
+.insight-card.enter {
+  animation: float-in 420ms ease;
+}
+
+.insight-card[data-state='overview'] .insight-steps {
+  display: none;
+}
+
+.insight-card[data-state='steps'] .insight-steps {
+  display: grid;
+}
+
+.insight-steps {
+  margin: 6px 0 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 14px;
+  counter-reset: step;
+}
+
+.insight-steps li {
+  position: relative;
+  padding-left: 42px;
+  min-height: 32px;
+  font-size: 15px;
+  line-height: 1.5;
+  color: rgba(214, 228, 255, 0.88);
+  text-shadow: 0 0 14px rgba(130, 190, 255, 0.45);
+}
+
+.insight-steps li::before {
+  counter-increment: step;
+  content: counter(step, decimal-leading-zero);
+  position: absolute;
+  left: 0;
+  top: 2px;
+  width: 30px;
+  height: 30px;
+  border-radius: 12px;
+  background: rgba(123, 187, 255, 0.2);
+  border: 1px solid rgba(170, 214, 255, 0.5);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  color: rgba(240, 248, 255, 0.9);
+  box-shadow: 0 12px 28px rgba(59, 108, 255, 0.28);
+  backdrop-filter: blur(16px);
+}
+
+.insight-steps li strong {
+  display: block;
+  font-size: 15px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(240, 248, 255, 0.92);
+  margin-bottom: 4px;
+}
+
+.insight-steps li span {
+  display: block;
+  font-size: 14px;
+  color: rgba(210, 224, 255, 0.75);
+}
+
+.chat-input-area {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .input-wrapper {
   position: relative;
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
+  padding: 14px 16px;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: linear-gradient(180deg, rgba(18, 28, 52, 0.72), rgba(18, 28, 52, 0.45));
+  backdrop-filter: blur(24px);
+  box-shadow: inset 0 0 24px rgba(120, 184, 255, 0.15);
 }
 
 #chat-input {
+  flex: 1;
   width: 100%;
-  min-height: 40px;
-  max-height: 240px;
+  min-height: 56px;
+  max-height: 220px;
   resize: none;
   border: none;
   outline: none;
   background: transparent;
-  color: #f2f6ff;
-  font-size: 20px;
-  line-height: 1.4;
-  text-shadow: 0 0 12px rgba(130, 190, 255, 0.65);
-  caret-color: #8ab4ff;
-  padding-right: 8px;
+  color: rgba(240, 246, 255, 0.95);
+  font-size: 18px;
+  line-height: 1.6;
+  text-shadow: 0 0 18px rgba(150, 210, 255, 0.75);
+  caret-color: #90c2ff;
+  padding: 0;
+  overflow-y: hidden;
 }
 
 #chat-input::placeholder {
-  color: rgba(226, 235, 255, 0.45);
+  color: rgba(205, 224, 255, 0.55);
   text-shadow: none;
 }
 
+.send-button {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 12px 20px;
+  border-radius: 18px;
+  border: 1px solid rgba(170, 214, 255, 0.45);
+  background: linear-gradient(130deg, rgba(64, 110, 255, 0.85), rgba(129, 206, 255, 0.65));
+  color: #f7fbff;
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  cursor: pointer;
+  text-shadow: 0 0 18px rgba(120, 190, 255, 0.85);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  overflow: hidden;
+}
+
+.send-button.is-ready {
+  background: linear-gradient(130deg, rgba(84, 150, 255, 0.95), rgba(155, 226, 255, 0.8));
+  box-shadow: 0 18px 42px rgba(80, 140, 255, 0.48);
+}
+
+.send-button::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.28);
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.send-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 40px rgba(60, 110, 255, 0.42);
+}
+
+.send-button:active {
+  transform: translateY(1px) scale(0.98);
+}
+
+.send-button-glow {
+  position: absolute;
+  inset: -40% -20%;
+  background: radial-gradient(circle at 30% 30%, rgba(215, 245, 255, 0.55), transparent 60%);
+  opacity: 0.8;
+  pointer-events: none;
+  filter: blur(2px);
+}
+
+.send-button-label {
+  position: relative;
+  z-index: 1;
+}
+
 #status {
-  margin-top: 8px;
+  min-height: 18px;
   font-size: 13px;
-  color: rgba(255, 255, 255, 0.7);
-  min-height: 16px;
+  letter-spacing: 0.04em;
+  color: rgba(195, 214, 247, 0.75);
+  text-shadow: 0 0 14px rgba(140, 196, 255, 0.35);
+}
+
+@keyframes float-in {
+  0% {
+    opacity: 0;
+    transform: translateY(12px) scale(0.98);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
 }

--- a/renderer/overlay/index.html
+++ b/renderer/overlay/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <button id="overlay-button" aria-label="Open copilot chat">
+    <button id="overlay-button" type="button" aria-label="Toggle copilot chat" aria-pressed="false">
       <span class="glow"></span>
       <span class="label">⋯</span>
     </button>

--- a/renderer/overlay/script.js
+++ b/renderer/overlay/script.js
@@ -1,3 +1,27 @@
-document.getElementById('overlay-button').addEventListener('click', () => {
-  window.electronAPI.openChat();
+const button = document.getElementById('overlay-button');
+let chatOpen = false;
+
+const updateState = () => {
+  button.setAttribute('aria-pressed', chatOpen ? 'true' : 'false');
+  button.classList.toggle('active', chatOpen);
+};
+
+button.addEventListener('click', () => {
+  if (chatOpen) {
+    window.electronAPI.hideChat();
+  } else {
+    window.electronAPI.openChat();
+  }
 });
+
+window.electronAPI.onChatOpened(() => {
+  chatOpen = true;
+  updateState();
+});
+
+window.electronAPI.onChatClosed(() => {
+  chatOpen = false;
+  updateState();
+});
+
+updateState();

--- a/renderer/overlay/styles.css
+++ b/renderer/overlay/styles.css
@@ -14,46 +14,94 @@ body {
   height: 100%;
   background: transparent;
   font-family: 'SF Pro Text', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
 }
 
 #overlay-button {
   position: relative;
-  width: 56px;
-  height: 56px;
+  width: 64px;
+  height: 64px;
   border-radius: 50%;
-  border: none;
+  border: 1px solid rgba(255, 255, 255, 0.2);
   outline: none;
   cursor: pointer;
-  background: rgba(65, 105, 225, 0.85);
-  box-shadow: 0 12px 32px rgba(65, 105, 225, 0.45);
+  background: linear-gradient(145deg, rgba(21, 28, 45, 0.6), rgba(31, 47, 76, 0.3));
+  backdrop-filter: blur(18px) saturate(160%);
+  box-shadow: 0 24px 50px rgba(0, 10, 40, 0.45);
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-  color: #fff;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.3s ease;
+  color: #f8fbff;
   overflow: hidden;
 }
 
+#overlay-button::after {
+  content: '';
+  position: absolute;
+  inset: 6px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 0 18px rgba(125, 200, 255, 0.22);
+  opacity: 0.85;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+}
+
 #overlay-button:hover {
-  transform: scale(1.05);
-  box-shadow: 0 16px 40px rgba(65, 105, 225, 0.6);
+  transform: translateY(-2px) scale(1.04);
+  box-shadow: 0 30px 60px rgba(0, 15, 60, 0.55);
 }
 
 #overlay-button:active {
-  transform: scale(0.96);
+  transform: translateY(0) scale(0.97);
 }
 
 #overlay-button .glow {
   position: absolute;
-  inset: -40%;
-  background: radial-gradient(circle at center, rgba(255, 255, 255, 0.5), transparent 60%);
-  opacity: 0.8;
+  inset: -45%;
+  background: radial-gradient(circle at 35% 30%, rgba(160, 206, 255, 0.45), transparent 65%);
+  opacity: 0.9;
   pointer-events: none;
+  filter: blur(2px);
+  animation: shimmer 4.5s ease-in-out infinite;
 }
 
 #overlay-button .label {
   position: relative;
   font-size: 28px;
   line-height: 1;
+  font-weight: 600;
+  letter-spacing: 2px;
+  color: rgba(255, 255, 255, 0.92);
+  text-shadow: 0 0 14px rgba(160, 206, 255, 0.8);
   pointer-events: none;
+  transition: transform 0.3s ease;
+}
+
+#overlay-button.active {
+  border-color: rgba(123, 202, 255, 0.65);
+  box-shadow: 0 28px 72px rgba(35, 120, 255, 0.55);
+}
+
+#overlay-button.active::after {
+  opacity: 1;
+}
+
+#overlay-button.active .label {
+  transform: scale(0.9);
+}
+
+@keyframes shimmer {
+  0%,
+  100% {
+    transform: translate(-10%, -12%) scale(1);
+    opacity: 0.6;
+  }
+  45% {
+    transform: translate(8%, 6%) scale(1.05);
+    opacity: 1;
+  }
 }


### PR DESCRIPTION
## Summary
- redesign the floating overlay toggle and chat window with glassmorphic styling, glowing typography, and bottom-right positioning
- add an overview/next steps insight deck with navigation plus a send button while keeping the capture workflow intact
- start the highlight animation from the chat origin and synchronize overlay toggle state via new IPC hooks

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d755f777cc832c8c8743667265a598